### PR TITLE
Add repeat frequency options for tasks                                                  Mikaella/task list

### DIFF
--- a/src/main/java/controller/TaskListController.java
+++ b/src/main/java/controller/TaskListController.java
@@ -443,14 +443,18 @@ public class TaskListController {
         //    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy");
         //    dueDate = dueDatePicker.getValue().format(formatter);
 
-        dueDate = formatDueDate(dueDatePicker.getValue());
+        //dueDate = formatDueDate(dueDatePicker.getValue());
+        LocalDate selected_due_date = dueDatePicker.getValue();
+        dueDate = formatDueDate(selected_due_date);
+        String repeat_date = next_repeat_date(selected_due_date, repeat);
         //}
 
         return title.trim()
                 + " | " + description.trim()
                 + " | Due: " + dueDate
                 + " | Priority: " + priority
-                + " | Repeat: " + repeat;
+                + " | Repeat: " + repeat
+                + " | Next Repeat" + repeat_date;
     }
 
     //clears all in out fields after user adds, edit or deletes a task
@@ -471,6 +475,46 @@ public class TaskListController {
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/dd/yyyy");
         return date.format(formatter);
+    }
+
+    private String next_repeat_date(LocalDate due_date, String repeat) {
+        //no due date means no repeat to calculate
+        if (due_date == null) {
+            return "No repeat date";
+        }
+
+        //if user did not choose to repeat task, dont calculate a date
+        if (repeat == null || repeat.equals("None")) {
+            return "Does not repeat";
+        }
+
+        LocalDate next_date;
+
+        //add date based on the repeat option selected by user
+        if (repeat.equals("Daily")) {
+            next_date = due_date.plusDays(1);
+        }
+        else if (repeat.equals("Weekly")) {
+            next_date = due_date.plusWeeks(1);
+        }
+
+        else if (repeat.equals("Bi-Weekly")) {
+            next_date = due_date.plusWeeks(2);
+        }
+
+        else if (repeat.equals("Monthly")) {
+            next_date = due_date.plusMonths(1);
+        }
+        else if (repeat.equals("Yearly")) {
+            next_date = due_date.plusYears(1);
+        }
+
+        else {
+            return "Does not repeat.";
+        }
+
+        //format date correctly
+        return formatDueDate(next_date);
     }
 
     //shows the warning popups

--- a/src/main/java/controller/TaskListController.java
+++ b/src/main/java/controller/TaskListController.java
@@ -24,6 +24,10 @@ public class TaskListController {
     @FXML
     private ComboBox<String> priorityBox;
 
+    //dropdown so users can choose repeat frequency for tasks
+    @FXML
+    private ComboBox<String> repeatBox;
+
     //displays save changes button for when users edit
     @FXML
     private Button saveChangesButton;
@@ -38,12 +42,17 @@ public class TaskListController {
     //lets users choose prioroty level fo task
     @FXML
     private void initialize() {
+        //shows priority level
         priorityBox.getItems().addAll("Low", "Medium", "High");
 
+        //gives user options on how to sort their priorities
         sortBox.getItems().addAll("Sort by Priority", "Sort by Due Date");
 
+        //gives the options to how often their task repeats
+        repeatBox.getItems().addAll("None", "Daily", "Weekly", "Bi-Weekly", "Monthly", "Yearly");
+
         //bolds task title
-        boldTaskTitle();
+        bold_task_title();
 
         //when user clicks the task all task information loaded back to input fields to be edited
         taskListView.getSelectionModel().selectedItemProperty().addListener((task_list, old_task, new_task) -> {
@@ -97,10 +106,23 @@ public class TaskListController {
                 priorityBox.setValue(priority_text); //show the chosen priority
             }
         }
+
+        //puts the chosen frewuncy back into the drop down option so they can chnage it later
+        if (task_parts.length > 4) {
+            String repeat_text = task_parts[4].replace("Repeat:", "").trim();
+
+            //if the repeat frequency is none, show none
+            if (repeat_text.equals("None")) {
+                repeatBox.setValue("None");
+            }
+            else {
+                repeatBox.setValue(repeat_text);
+            }
+        }
     }
 
     //function will bold the task title onlty
-    private void boldTaskTitle() {
+    private void bold_task_title() {
         taskListView.setCellFactory(listView -> new ListCell<String>() {
             @Override
             //protected because im updating the task title to be bold, not changing what it says
@@ -173,7 +195,7 @@ public class TaskListController {
 
         //add new task at index 0 so newest task appears first
         taskListView.getItems().add(0, task_text);
-        clearFields();
+        clear_fields();
     }
 
     //updates currently selected task
@@ -207,7 +229,7 @@ public class TaskListController {
         }
 
         taskListView.getItems().set(selected_index, task_text);
-        clearFields();*/
+        clear_fields();*/
     }
 
     //saves the edited task after user clicks saves changes
@@ -240,7 +262,7 @@ public class TaskListController {
         saveChangesButton.setManaged(false);
 
         //clears input fields after user saves their changes
-        clearFields();
+        clear_fields();
 
     }
 
@@ -255,7 +277,7 @@ public class TaskListController {
         }
 
         taskListView.getItems().remove(selected_index);
-        clearFields();
+        clear_fields();
     }
 
     //will sort task based on selected priority sorting option
@@ -271,17 +293,17 @@ public class TaskListController {
 
         //if user did select an option function call and sort the tasks
         if (selected_sort.equals("Sort by Priority")) {
-            sortbyPriority();
+            sort_by_priority();
         }
 
         //if user chose to sort task by due date call the function to sort bu due date
         if (selected_sort.equals("Sort by Due Date")) {
-            sortbyDueDate();
+            sort_by_due_date();
         }
     }
 
     //sort task by priory
-    private void sortbyPriority() {
+    private void sort_by_priority() {
         taskListView.getItems().sort((first_task, second_task) -> {
             //gets priority value for the first task
             int first_priority = getPriorityValue(first_task);
@@ -315,7 +337,7 @@ public class TaskListController {
     }
 
     //sorts tasks so that closest due date appears more
-    private void sortbyDueDate() {
+    private void sort_by_due_date() {
 
         taskListView.getItems().sort((task1, task2) -> {
             //gets due date of first task
@@ -399,13 +421,19 @@ public class TaskListController {
 
         String description = descriptionArea.getText();
         String priority = priorityBox.getValue();
+        String repeat = repeatBox.getValue();
 
         if (description == null || description.trim().isEmpty()) {
             description = "No description.";
         }
 
+
         if (priority == null) {
             priority = "No priority";
+        }
+
+        if (repeat == null) {
+            repeat = "None";
         }
 
         String dueDate = "No due date";
@@ -421,15 +449,17 @@ public class TaskListController {
         return title.trim()
                 + " | " + description.trim()
                 + " | Due: " + dueDate
-                + " | Priority: " + priority;
+                + " | Priority: " + priority
+                + " | Repeat: " + repeat;
     }
 
     //clears all in out fields after user adds, edit or deletes a task
-    private void clearFields() {
+    private void clear_fields() {
         titleField.clear();
         descriptionArea.clear();
         dueDatePicker.setValue(null);
         priorityBox.setValue(null);
+        repeatBox.setValue(null);
     }
 
     //ADDED FOR TESTING

--- a/src/main/java/controller/TaskListController.java
+++ b/src/main/java/controller/TaskListController.java
@@ -454,7 +454,7 @@ public class TaskListController {
                 + " | Due: " + dueDate
                 + " | Priority: " + priority
                 + " | Repeat: " + repeat
-                + " | Next Repeat" + repeat_date;
+                + " | Next Repeat " + repeat_date;
     }
 
     //clears all in out fields after user adds, edit or deletes a task

--- a/src/main/resources/fxml/task-list.fxml
+++ b/src/main/resources/fxml/task-list.fxml
@@ -24,6 +24,8 @@
 
             <ComboBox fx:id = "priorityBox" promptText="Priority" />
 
+            <ComboBox fx:id = "repeatBox" promptText="Repeat" />
+
             <ComboBox fx:id = "sortBox" promptText="Sort Tasks" onAction="#handleSortTasks"/>
 
             <HBox spacing="10" >


### PR DESCRIPTION
What happened
- added a Repeat dropdown for tasks with options: None, Daily, Weekly, Bi-Weekly, Monthly, and Yearly
- task displays selected repeat frequency of task
- added next repeat date based on the task due date
- user can edit repeat frequency when editing task

How I tested
- i added a task with no repeat option
- i added tasks with Daily, Weekly, Bi-Weekly, Monthly, and Yearly repeat options
- this verified the selected repeat frequency appears in the task list
- i was able to verify next repeat date is calculated correctly
- i was able to verify repeat frequency can be changed while editing a task